### PR TITLE
Cleanup the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-UCompiler-Plugin-NewLine
-======================
+# UCompiler-Plugin-NewLine
 
-This plugin for ucompiler makes sure that your generated files always end with a new line.
-It also normalizes their EOLs to LF.
+This plugin for ucompiler makes sure that your generated files always end with
+a new line. It also normalizes their EOLs to LF.
 
+## How to Use
 
-#### How to Use
-
-Simply add "newline" to `plugins` field in your `.ucompilerrc`
+You first need to add `ucompiler-plugin-newline` to your `devDependencies`
+within your `package.json`, then simply add "newline" to the `plugins` field
+in your `.ucompilerrc` configuration file.
 
 ```js
 {
@@ -15,6 +15,6 @@ Simply add "newline" to `plugins` field in your `.ucompilerrc`
 }
 ```
 
-#### License
+## License
 
 This project is licensed under the terms of MIT License


### PR DESCRIPTION
- Cleanup some issues exposed by `remark-lint`.
- Mention that the package needs to be added to `package.json`.
